### PR TITLE
Fix for using FLAG_IMMUTABLE when creating PendingIntent targeting S+ (version 31 and above)

### DIFF
--- a/android/src/main/java/io/tradle/nfc/RNPassportReaderModule.java
+++ b/android/src/main/java/io/tradle/nfc/RNPassportReaderModule.java
@@ -189,7 +189,8 @@ public class RNPassportReaderModule extends ReactContextBaseJavaModule implement
     Activity activity = getCurrentActivity();
     Intent intent = new Intent(activity.getApplicationContext(), activity.getClass());
     intent.setFlags(Intent.FLAG_ACTIVITY_SINGLE_TOP);
-    PendingIntent pendingIntent = PendingIntent.getActivity(getCurrentActivity(), 0, intent, 0);//PendingIntent.FLAG_UPDATE_CURRENT);
+    PendingIntent pendingIntent = PendingIntent.getActivity(getCurrentActivity(), 0, intent, PendingIntent.FLAG_IMMUTABLE | PendingIntent.FLAG_UPDATE_CURRENT);//PendingIntent.FLAG_UPDATE_CURRENT);
+
     String[][] filter = new String[][] { new String[] { IsoDep.class.getName()  } };
     mNfcAdapter.enableForegroundDispatch(getCurrentActivity(), pendingIntent, null, filter);
   }


### PR DESCRIPTION
This pull request addresses an issue that arises when creating a PendingIntent targeting S+ (version 31 and above) without specifying either FLAG_IMMUTABLE or FLAG_MUTABLE. The change implements a resolution by utilizing PendingIntent.FLAG_IMMUTABLE for creating the PendingIntent, as recommended.

This modification enhances security and performance by employing the recommended FLAG_IMMUTABLE, providing a PendingIntent that is immutable and therefore safer for use. FLAG_MUTABLE is only necessary in specific cases, such as inline replies or bubbles.

This pull request aims to ensure compatibility with S+ version and above by embracing and applying the usage of FLAG_IMMUTABLE.

Changes:
Implemented PendingIntent creation using PendingIntent.FLAG_IMMUTABLE